### PR TITLE
update account to be a select widget

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,16 +1,26 @@
+<%-
+  groups = OodSupport::User.new.groups.sort_by(&:id).tap { |groups|
+    groups.unshift(groups.delete(OodSupport::Process.group))
+  }.map(&:name).grep(/^P./)
+-%>
+---
 cluster:
   - "owens"
   - "pitzer"
 form:
-  - bc_account
+  - account
   - bc_num_hours
   - num_cores
   - node_type
   - version
 attributes:
-  bc_account:
+  account:
     label: "Project"
-    help: "You can leave this blank if **not** in multiple projects."
+    widget: select
+    options:
+      <%- groups.each do |group| %>
+      - "<%= group %>"
+      <%- end %>
   num_cores:
     widget: "number_field"
     label: "Number of cores"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -27,6 +27,7 @@
 batch_connect:
   template: vnc
 script:
+  accounting_id: "<%= account %>"
   native:
   <%- args.each do |arg| %>
     - "<%= arg %>"


### PR DESCRIPTION
This changes the account field to be a select widget for only valid project codes to help users only use valid project codes while forcing them to supply one.